### PR TITLE
升级gradle-git-properties插件，修复shallow clone build失败

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         classpath "org.grails.plugins:hibernate5:${gormVersion - ".RELEASE"}"
         classpath "org.grails.plugins:views-gradle:1.2.8"
         classpath 'org.grails.plugins:database-migration:3.0.4'
-        classpath "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.5.1"
+        classpath "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.5.2"
     }
 }
 


### PR DESCRIPTION
升级gradle-git-properties插件，修复shallow clone build失败。新版本插件解决了GitProperties这个task在shallow clone报错`Missing commit`的异常